### PR TITLE
Expose unit attribute from graph on ConditionalInput and Question

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/model/ConditionalInput.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/model/ConditionalInput.java
@@ -20,4 +20,6 @@ public class ConditionalInput {
    */
   QuestionType type;
 
+  Unit unit;
+
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/model/QuestionDefinition.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/model/QuestionDefinition.java
@@ -20,5 +20,6 @@ public class QuestionDefinition {
   String pattern;
   QuestionType type;
   List<AnswerDefinition> answerDefinitions;
+  Unit unit;
 
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/model/Unit.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/model/Unit.java
@@ -1,0 +1,28 @@
+package uk.gov.crowncommercial.dts.scale.service.gm.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Unit of value for numerical conditional input / question types
+ */
+public enum Unit {
+
+  @JsonProperty("currency")
+  CURRENCY,
+
+  @JsonProperty("quantity")
+  QUANTITY,
+
+  @JsonProperty("days")
+  DAYS,
+
+  @JsonProperty("weeks")
+  WEEKS,
+
+  @JsonProperty("months")
+  MONTHS,
+
+  @JsonProperty("years")
+  YEARS;
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/model/ogm/Question.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/model/ogm/Question.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.experimental.FieldDefaults;
 import uk.gov.crowncommercial.dts.scale.service.gm.model.QuestionType;
+import uk.gov.crowncommercial.dts.scale.service.gm.model.Unit;
 
 /**
  *
@@ -19,5 +20,6 @@ public class Question {
   String hint;
   String pattern;
   QuestionType type;
+  Unit unit;
 
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/service/QuestionService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/service/QuestionService.java
@@ -71,11 +71,11 @@ public class QuestionService {
 
     return QuestionDefinition.builder().uuid(questionInstance.getUuid()).text(question.getText())
         .type(question.getType()).hint(question.getHint()).pattern(question.getPattern())
-        .answerDefinitions(answerDefinitions).build();
+        .answerDefinitions(answerDefinitions).unit(question.getUnit()).build();
   }
 
   private Optional<ConditionalInput> getConditionalInputFromAnswer(final Answer answer) {
     return Optional.ofNullable(answer.getConditionalInputQuestion())
-        .map(q -> new ConditionalInput(q.getText(), q.getHint(), q.getType()));
+        .map(q -> new ConditionalInput(q.getText(), q.getHint(), q.getType(), q.getUnit()));
   }
 }


### PR DESCRIPTION
New unit property - will always be null (i.e. omitted from the API) on either / both types depending on the question type.  Currently we only have `ConditionalInput`, no free-entry numeric question types so it will only appear on that type in the API at present.